### PR TITLE
caffe api update

### DIFF
--- a/cnn/cnnFeaExtraction.m
+++ b/cnn/cnnFeaExtraction.m
@@ -15,9 +15,8 @@ imIndex = find(imdb.images.class == classId);
 model_def_file = 'deploy1_fc6.prototxt';
 % NOTE: you'll have to get the pre-trained ILSVRC network
 model_file = [conf.pathToModel,'/bvlc_reference_caffenet.caffemodel'];
-caffe('init',model_def_file,model_file);
+caffe('init',model_def_file,model_file,'test');
 caffe('set_mode_cpu');
-caffe('set_phase_test');
 d = load('ilsvrc_2012_mean.mat');
 IMAGE_MEAN = d.image_mean;
 IMAGE_DIM = 256;

--- a/cnn/cnnFeaExtraction_L2.m
+++ b/cnn/cnnFeaExtraction_L2.m
@@ -15,9 +15,8 @@ imIndex = find(imdb.images.class == classId);
 model_def_file = 'deploy1_fc6.prototxt';
 % NOTE: you'll have to get the pre-trained ILSVRC network
 model_file = [conf.pathToModel,'/bvlc_reference_caffenet.caffemodel'];
-caffe('init',model_def_file,model_file);
+caffe('init',model_def_file,model_file,'test');
 caffe('set_mode_cpu');
-caffe('set_phase_test');
 d = load('ilsvrc_2012_mean.mat');
 IMAGE_MEAN = d.image_mean;
 IMAGE_DIM = 256;

--- a/cnn/cnnFeaExtraction_L3.m
+++ b/cnn/cnnFeaExtraction_L3.m
@@ -15,9 +15,8 @@ imIndex = find(imdb.images.class == classId);
 model_def_file = 'deploy1_fc6.prototxt';
 % NOTE: you'll have to get the pre-trained ILSVRC network
 model_file = [conf.pathToModel,'/bvlc_reference_caffenet.caffemodel'];
-caffe('init',model_def_file,model_file);
+caffe('init',model_def_file,model_file,'test');
 caffe('set_mode_cpu');
-caffe('set_phase_test');
 d = load('ilsvrc_2012_mean.mat');
 IMAGE_MEAN = d.image_mean;
 IMAGE_DIM = 256;


### PR DESCRIPTION
Your use of the matcaffe API is out of date with respect to caffe/master.  The test phase is now specified in the call to init.

An alternative would be to include a git submodule pointing to the bvlc/caffe commit that you developed against.

This part of the API was changed in this commit.
https://github.com/BVLC/caffe/commit/bb8b5d60eb47dff3977377a2a4db4fe9f2fbee62
